### PR TITLE
Add disability as an API input as per Head Start suggestion 

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ curl -X POST -H "Content-Type: application/json" \
 
 ## Rebuild
 
-Some changes to the code — for example, adding a new input variable — require re-building the project before they are available to you locally. Run:
+Some changes to the code — for example, adding a new input variable — require re-building the project before they become available to you locally. Run:
 
 ```
 make build

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ curl -X POST -H "Content-Type: application/json" \
   -d @./prototype_usa_head_start/situation_examples/disability.json http://localhost:5000/calculate
 ```
 
+## Rebuild
+
+Some changes to the code — for example, adding a new input variable — require re-building the project before they are available to you locally. Run:
+
+```
+make build
+```
+
 ## Deploy
 
 This app has been configured to deploy to [cloud.gov](https://cloud.gov/) with a `manifest.yml` file.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ curl -X POST -H "Content-Type: application/json" \
 # Family that is eligible for multiple reasons
 curl -X POST -H "Content-Type: application/json" \
   -d @./prototype_usa_head_start/situation_examples/family_eligible_multiple_reasons.json http://localhost:5000/calculate
+
+# Family with a child who has a disability
+curl -X POST -H "Content-Type: application/json" \
+  -d @./prototype_usa_head_start/situation_examples/disability.json http://localhost:5000/calculate
 ```
 
 ## Deploy

--- a/prototype_usa_head_start/situation_examples/disability.json
+++ b/prototype_usa_head_start/situation_examples/disability.json
@@ -1,0 +1,14 @@
+{
+    "families": {
+        "_": {
+            "homelessness": { "2019": true },
+            "fostercare": { "2019": false },
+            "eligible_tanf_or_ssi": { "2019": false },
+            "household_size": { "2019": 2 },
+            "state_or_territory": { "2019": "CA" },
+            "income": { "2019": 60000 },
+            "head_start_eligibility_status": { "2019": null },
+            "disability": { "2019": true }
+        }
+    }
+}

--- a/prototype_usa_head_start/situation_examples/disability.json
+++ b/prototype_usa_head_start/situation_examples/disability.json
@@ -1,7 +1,7 @@
 {
     "families": {
         "_": {
-            "homelessness": { "2019": true },
+            "homelessness": { "2019": false },
             "fostercare": { "2019": false },
             "eligible_tanf_or_ssi": { "2019": false },
             "household_size": { "2019": 2 },

--- a/prototype_usa_head_start/variables/inputs.py
+++ b/prototype_usa_head_start/variables/inputs.py
@@ -50,3 +50,11 @@ class state_or_territory(Variable):
     entity = Family
     label = u"U.S. state, territory, or district where the family lives"
     definition_period = YEAR
+
+
+class disability(Variable):
+    value_type = bool
+    entity = Family
+    label = u"Does the child have a disability? Head Start programs must ensure at least 10 percent of its total funded enrollment is filled by children eligible for services under IDEA, the Individuals with Disabilities Education Act."
+    definition_period = YEAR
+    reference = "https://eclkc.ohs.acf.hhs.gov/policy/45-cfr-chap-xiii/1302-14-selection-process"

--- a/prototype_usa_head_start/variables/outputs.py
+++ b/prototype_usa_head_start/variables/outputs.py
@@ -121,6 +121,12 @@ class head_start_eligibility_status(Variable):
             ' Eligible because family is below the federal poverty line.'
             )
 
-        result = with_poverty_line_factor
+        with_disability_factor = add_eligibility_reason(
+            with_poverty_line_factor,
+            family('disability', period),
+            ' May be eligible due to the child\'s disability. Head Start programs must fill 10 percent of slots with children covered by the Individuals with Disabilities Education Act.'
+            )
+
+        result = with_disability_factor
 
         return result

--- a/prototype_usa_head_start/variables/outputs.py
+++ b/prototype_usa_head_start/variables/outputs.py
@@ -91,6 +91,9 @@ class head_start_eligibility_status(Variable):
     label = u"Head Start Eligibility Status"
 
     def formula(family, period, parameters):
+        # TODO (ARS): Check with Head Start about whether the API should return
+        # may be status or eligible status for child with a disability.
+
         eligible_status = 'Eligible for Head Start. Slot in a program not guaranteed.'
         maybe_status = 'May be Eligible, depending on the child\'s needs and the slots available.'
         eligibility_boolean = family('head_start_eligibility_bool', period)


### PR DESCRIPTION
Input:

```
curl -X POST -H "Content-Type: application/json" \
  -d @./prototype_usa_head_start/situation_examples/disability.json http://localhost:5000/calculate | jq
```

Output:

```
{
  "families": {
    "_": {
      "homelessness": {
        "2019": false
      },
      "fostercare": {
        "2019": false
      },
      "eligible_tanf_or_ssi": {
        "2019": false
      },
      "household_size": {
        "2019": 2
      },
      "state_or_territory": {
        "2019": "CA"
      },
      "income": {
        "2019": 60000
      },
      "head_start_eligibility_status": {
        "2019": "May be Eligible, depending on the child's needs and the slots available. May be eligible due to the child's disability. Head Start programs must fill 10 percent of slots with children covered by the Individuals with Disabilities Education Act."
      },
      "disability": {
        "2019": true
      }
    }
  }
}
```

# TODO 

Check with Head Start about whether to return "Eligible" status or "Maybe" status if the child has a disability. 