### PR TITLE
Add API results for 100% < income =< 130% FPL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ test: clean check-syntax-errors check-style
 test-dev: clean check-syntax-errors
 	openfisca test --country-package prototype_usa_head_start prototype_usa_head_start/tests
 
-serve-local:
+serve-local: build
 	openfisca serve --country-package prototype_usa_head_start --port 5000
 
 serve: build

--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ Or, for a prettier JSON response, use [jq](https://stedolan.github.io/jq/):
 curl -X POST -H "Content-Type: application/json" \
   -d @./prototype_usa_head_start/situation_examples/disability.json http://localhost:5000/calculate \
   | jq
+
+# Family with income slightly above the federal poverty level
+curl -X POST -H "Content-Type: application/json" \
+  -d @./prototype_usa_head_start/situation_examples/family_slightly_above_100_fpl_il.json http://localhost:5000/calculate \
+  | jq
 ```
 
 ## Rebuild

--- a/prototype_usa_head_start/situation_examples/family_slightly_above_100_fpl_il.json
+++ b/prototype_usa_head_start/situation_examples/family_slightly_above_100_fpl_il.json
@@ -1,0 +1,13 @@
+{
+    "families": {
+        "_": {
+            "homelessness": { "2019": false },
+            "fostercare": { "2019": false },
+            "eligible_tanf_or_ssi": { "2019": false },
+            "household_size": { "2019": 2 },
+            "state_or_territory": { "2019": "IL" },
+            "income": { "2019": 16911 },
+            "head_start_eligibility_status": { "2019": null }
+        }
+    }
+}

--- a/prototype_usa_head_start/tests/head_start.yaml
+++ b/prototype_usa_head_start/tests/head_start.yaml
@@ -105,3 +105,52 @@
     household_size: 9
   output:
     head_start_eligibility_bool: False
+
+- name: A family whose income is the same as the FPL for their state does not fall between 100% and 130% of FPL (it falls under "equal to or below the poverty level" instead and means the family is eligible)
+  period: 2019
+  input:
+    homelessness: False
+    fostercare: False
+    eligible_tanf_or_ssi: False
+    income: 16_910
+    state_or_territory: IL
+    household_size: 2
+  output:
+    income_between_fpl_and_130_fpl: False
+
+- name: A family whose income is $1 above the FPL for their state and household size falls between 100% and 130% of FPL
+  period: 2019
+  input:
+    homelessness: False
+    fostercare: False
+    eligible_tanf_or_ssi: False
+    income: 16_911
+    state_or_territory: IL
+    household_size: 2
+  output:
+    income_between_fpl_and_130_fpl: True
+
+- name: A family whose income is exactly 130% of the FPL for their state and household size falls between 100% and 130% of FPL
+  period: 2019
+  input:
+    homelessness: False
+    fostercare: False
+    eligible_tanf_or_ssi: False
+    income: 21_983
+    state_or_territory: IL
+    household_size: 2
+  output:
+    income_between_fpl_and_130_fpl: True # This is currently failing...
+
+- name: A family whose income is $1 above 130% of the FPL for their state and household size does not fall between 100% and 130% of FPL
+  period: 2019
+  input:
+    homelessness: False
+    fostercare: False
+    eligible_tanf_or_ssi: False
+    income: 21_984
+    state_or_territory: IL
+    household_size: 2
+  output:
+    income_between_fpl_and_130_fpl: False
+

--- a/prototype_usa_head_start/tests/head_start.yaml
+++ b/prototype_usa_head_start/tests/head_start.yaml
@@ -130,7 +130,7 @@
   output:
     income_between_fpl_and_130_fpl: True
 
-- name: A family whose income is exactly 130% of the FPL for their state and household size falls between 100% and 130% of FPL
+- name: A family whose income is exactly 130% of the FPL for their state and household size falls between 100% and 130% of FPL (the 130% is treated inclusively just as the 100% is treated inclusively in "equal to or below poverty level")
   period: 2019
   input:
     homelessness: False
@@ -140,7 +140,7 @@
     state_or_territory: IL
     household_size: 2
   output:
-    income_between_fpl_and_130_fpl: True # This is currently failing...
+    income_between_fpl_and_130_fpl: True
 
 - name: A family whose income is $1 above 130% of the FPL for their state and household size does not fall between 100% and 130% of FPL
   period: 2019

--- a/prototype_usa_head_start/variables/outputs.py
+++ b/prototype_usa_head_start/variables/outputs.py
@@ -57,11 +57,23 @@ class below_federal_poverty_level(Variable):
     value_type = bool
     entity = Family
     definition_period = YEAR
-    label = u"Is the family below the federal poverty level?"
+    label = u"Is the family's income below the federal poverty level?"
 
     def formula(family, period, parameters):
         return (
             family('federal_poverty_line_value', period) > family('income', period)
+            )
+
+
+class between_fpl_and_130_fpl(Variable):
+    value_type = bool
+    entity = Family
+    definition_period = YEAR
+    label = u"Is the family's income below 130 percent of the federal poverty level?"
+
+    def formula(family, period, parameters):
+        return (
+            (family('federal_poverty_line_value', period) * 1.3) > family('income', period) > family('federal_poverty_line_value', period)
             )
 
 
@@ -130,6 +142,12 @@ class head_start_eligibility_status(Variable):
             ' May be eligible due to the child\'s disability. Head Start programs must fill 10 percent of slots with children covered by the Individuals with Disabilities Education Act.'
             )
 
-        result = with_disability_factor
+        with_130_fpl_factor = add_eligibility_reason(
+            with_disability_factor,
+            family('between_fpl_and_130_fpl', period),
+            ' May be eligible because family income is below 130 percent of the federal poverty level. Some Head Start programs have additional capacity for children have families at this income level.'
+            )
+
+        result = with_130_fpl_factor
 
         return result

--- a/prototype_usa_head_start/variables/outputs.py
+++ b/prototype_usa_head_start/variables/outputs.py
@@ -113,7 +113,7 @@ class head_start_eligibility_status(Variable):
     def formula(family, period, parameters):
         # TODO (ARS): Check with Head Start about whether the API should return
         # may be status or eligible status for child with a disability.
-
+        # TODO (ARS): Same with ([100% FPL] < income =< [130% FPL]).
         eligible_status = 'Eligible for Head Start. Slot in a program not guaranteed.'
         maybe_status = 'May be Eligible, depending on the child\'s needs and the slots available.'
         eligibility_boolean = family('head_start_eligibility_bool', period)
@@ -147,13 +147,15 @@ class head_start_eligibility_status(Variable):
         with_disability_factor = add_eligibility_reason(
             with_poverty_line_factor,
             family('disability', period),
+            # TODO (ARS): Check language with Head Start counterparts.
             ' May be eligible due to the child\'s disability. Head Start programs must fill 10 percent of slots with children covered by the Individuals with Disabilities Education Act.'
             )
 
         with_130_fpl_factor = add_eligibility_reason(
             with_disability_factor,
             family('income_between_fpl_and_130_fpl', period),
-            ' May be eligible because family income is below 130 percent of the federal poverty level. Some Head Start programs have additional capacity for children have families at this income level.'
+            # TODO (ARS): Check language with Head Start counterparts.
+            ' May be eligible because family income is equal to or below 130 percent of the federal poverty level. Some Head Start programs have additional capacity for families with income in this range.'
             )
 
         result = with_130_fpl_factor

--- a/prototype_usa_head_start/variables/outputs.py
+++ b/prototype_usa_head_start/variables/outputs.py
@@ -53,15 +53,18 @@ class federal_poverty_line_value(Variable):
                     ))
 
 
-class below_federal_poverty_level(Variable):
+class equal_to_or_below_federal_poverty_level(Variable):
     value_type = bool
     entity = Family
     definition_period = YEAR
     label = u"Is the family's income below the federal poverty level?"
+    # From the policy:
+    # "Eligibility requirements. (1) A pregnant woman or a child is eligible if: (i) The family’s income is equal to or below the poverty line...""
+    # SOURCE: https://eclkc.ohs.acf.hhs.gov/policy/45-cfr-chap-xiii/1302-12-determining-verifying-documenting-eligibility
 
     def formula(family, period, parameters):
         return (
-            family('federal_poverty_line_value', period) > family('income', period)
+            family('federal_poverty_line_value', period) >= family('income', period)
             )
 
 
@@ -70,10 +73,14 @@ class income_between_fpl_and_130_fpl(Variable):
     entity = Family
     definition_period = YEAR
     label = u"Is the family's income below 130 percent of the federal poverty level?"
+    # From the policy:
+    # If a program chooses to enroll participants who do not meet a criterion in paragraph (c) of this section, and whose family incomes are between 100 and 130 percent of the poverty line, ...
+    # NOTE (ARS): Since the eligibility rules reference "equal to or below the poverty line" for purposes of determining eligibility, I interpret "between 100 and 130 percent" to be inclusive of 130 percent.
+    # SOURCE: https://eclkc.ohs.acf.hhs.gov/policy/45-cfr-chap-xiii/1302-12-determining-verifying-documenting-eligibility
 
     def formula(family, period, parameters):
         return (
-            (family('federal_poverty_line_value', period) * 1.3) > family('income', period) > family('federal_poverty_line_value', period)
+            (family('federal_poverty_line_value', period) * 1.3) >= family('income', period) > family('federal_poverty_line_value', period)
             )
 
 
@@ -88,7 +95,7 @@ class head_start_eligibility_bool(Variable):
             family('homelessness', period)
             + family('fostercare', period)
             + family('eligible_tanf_or_ssi', period)
-            + family('below_federal_poverty_level', period)
+            + family('equal_to_or_below_federal_poverty_level', period)
             )
 
 
@@ -132,7 +139,7 @@ class head_start_eligibility_status(Variable):
 
         with_poverty_line_factor = add_eligibility_reason(
             with_tanf_ssi_factor,
-            family('below_federal_poverty_level', period),
+            family('equal_to_or_below_federal_poverty_level', period),
             ' Eligible because family is below the federal poverty line.'
             )
 

--- a/prototype_usa_head_start/variables/outputs.py
+++ b/prototype_usa_head_start/variables/outputs.py
@@ -65,7 +65,7 @@ class below_federal_poverty_level(Variable):
             )
 
 
-class between_fpl_and_130_fpl(Variable):
+class income_between_fpl_and_130_fpl(Variable):
     value_type = bool
     entity = Family
     definition_period = YEAR
@@ -144,7 +144,7 @@ class head_start_eligibility_status(Variable):
 
         with_130_fpl_factor = add_eligibility_reason(
             with_disability_factor,
-            family('between_fpl_and_130_fpl', period),
+            family('income_between_fpl_and_130_fpl', period),
             ' May be eligible because family income is below 130 percent of the federal poverty level. Some Head Start programs have additional capacity for children have families at this income level.'
             )
 

--- a/prototype_usa_head_start/variables/outputs.py
+++ b/prototype_usa_head_start/variables/outputs.py
@@ -75,6 +75,7 @@ class income_between_fpl_and_130_fpl(Variable):
     label = u"Is the family's income below 130 percent of the federal poverty level?"
     # From the policy:
     # If a program chooses to enroll participants who do not meet a criterion in paragraph (c) of this section, and whose family incomes are between 100 and 130 percent of the poverty line, ...
+    # TODO (ARS): Check the below with Head Start.
     # NOTE (ARS): Since the eligibility rules reference "equal to or below the poverty line" for purposes of determining eligibility, I interpret "between 100 and 130 percent" to be inclusive of 130 percent.
     # SOURCE: https://eclkc.ohs.acf.hhs.gov/policy/45-cfr-chap-xiii/1302-12-determining-verifying-documenting-eligibility
 


### PR DESCRIPTION
# What does this change?

Add API results for 100% < income =< 130% FPL.

Example API result language for families whose income falls in this range: 

> "May be Eligible, depending on the child's needs and the slots available. May be eligible because family income is equal to or below 130 percent of the federal poverty level. Some Head Start programs have additional capacity for families with income in this range."

# Notes

+ Check handling of `income == 130% FPL` with Head Start. 
+ Check API result language with Head Start. 
+ Check test cases with Head Start.